### PR TITLE
Fix put and delete calls in ObjectStorageController.php

### DIFF
--- a/api/ObjectStorageController.php
+++ b/api/ObjectStorageController.php
@@ -720,7 +720,7 @@ abstract class ObjectStorageController {
           if ($objExists && $objSize != $bytes) {
             $objExists = FALSE;
             self::log(sprintf('Object %s/%s exists but is the incorrect size. Expecting %d bytes; Actual %d bytes. Attempting to delete...', $this->container, $name, $bytes, $objSize), 'ObjectStorageController::initObjects', __LINE__);
-            if ($this->deleteObject($container, $object)) self::log(sprintf('Object %s/%s deleted successfully', $this->container, $name), 'ObjectStorageController::initObjects', __LINE__);
+            if ($this->deleteObject($this->container, $object)) self::log(sprintf('Object %s/%s deleted successfully', $this->container, $name), 'ObjectStorageController::initObjects', __LINE__);
             else {
               $success = FALSE;
               self::log(sprintf('Unable to delete object %s/%s', $this->container, $name), 'ObjectStorageController::initObjects', __LINE__, TRUE);
@@ -1155,8 +1155,8 @@ abstract class ObjectStorageController {
         $request = array('url' => $upload['url'], 'method' => isset($upload['method']) ? $upload['method'] : 'PUT', 'headers' => isset($upload['headers'][$i - 1]) ? $upload['headers'][$i - 1] : $upload['headers']);
         // remove content-length header - this is set dynamically
         foreach(array_keys($request['headers']) as $key) if (strtolower($key) == 'content-length' || strtolower($key) == 'content-type') unset($request['headers'][$key]);
-        $request['headers']['Content-Length'] = $size;
-        $request['headers']['Content-Type'] = self::CONTENT_TYPE;
+        $request['headers']['content-length'] = $size;
+        $request['headers']['content-type'] = self::CONTENT_TYPE;
         $request['url'] = str_replace('{size}', $size, $request['url']);
         if ($parts) {
           $request['url'] = str_replace('{part}', $i, $request['url']);
@@ -1174,7 +1174,7 @@ abstract class ObjectStorageController {
       }
       $curl = array();
       foreach($requests as $request) {
-        $input = sprintf('%s/urandom.php %d', dirname(dirname(getenv('bm_run_dir'))), $request['headers']['Content-Length']);
+        $input = sprintf('%s/urandom.php %d', getenv('bm_run_dir'), $request['headers']['content-length']);
         $curl[] = array('method' => 'PUT', 'headers' => $request['headers'], 'url' => $request['url'], 'input' => $input);
         self::log(sprintf('Added curl request for %s', $request['url']), 'ObjectStorageController::upload', __LINE__);
       }


### PR DESCRIPTION
Code update 1:
Line 723:   if ($this->deleteObject($container, $object)) self::log(sprintf('Object %s/%s deleted successfully', $this->container, $name), 'ObjectStorageController::initObjects', __LINE__); 
            Changed : deleteObject($container, $object)) To deleteObject($this->container, $object)) 
 
This line was referencing the wrong variable for the container name, thus the delete would fail.  Making this change allowed the delete to work properly.  Since this is an uncommon code path outside the normal test, it’s probably not been hit by very many people.
 
 
Code update 2:
Line 1158:  $request['headers']['Content-Length'] = $size;
Line 1159:  $request['headers']['Content-Type'] = self::CONTENT_TYPE; 
             Changed : $request['headers']['Content-Type'] To $request['headers']['content-type']  (also Content-Length?)
 
In some places it looked like the code was using lower case names for content-type and content-length, and it other places it was using mixed case.  The particular problem here is that the request was being signed with the lower case values which were then replaced with upper case values, causing the (case-sensitive) signing to generate a different signature (which would then fail).  
 
More generally, the code is calling InitUpload (line 1142 or 1145) which (at least in the Azure case) is then computing a signature using the storage account key.  Then, a few lines further down we’re making changes in the header values, which (of course) runs the risk of invalidating the signature (specifically, I believe that content-type is part of the signature, not content-length).  
 
In the future, consider not computing a signature for a message until the message is fully built.  Alternatively, look at supporting SAS tokens as well as Storage Account Keys.  
 
 
Code update 3:
Line 1177: $input = sprintf('%s/urandom.php %d', dirname(dirname(getenv('bm_run_dir'))), $request['headers']['Content-Length']);
                    Changed to : $input = sprintf('%s/urandom.php %d', getenv('bm_run_dir'), $request['headers']['content-length']);
 
For some reason dirname was called twice on the run directory.  Other uses of this variable don't call dirname at all, so this aligns that usage.